### PR TITLE
Fix/android attestation validity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,11 +175,13 @@ out the attestation record.
         - autovalue: 1.11.0
         - protobuf-javalite: 4.27.0
 
-### 1.7.0 Breaking Changes Ahead!
+### 1.7.0
+
+**Breaking Changes Ahead!**
 
 - Add `AttestationValueException.Reason.TIME` to indicate too far off or missing attestation statement creation
   time inside the attestation statement (in contrast to Certificate validity issues)
 - Add `attestationStatementValiditySeconds` to Android attestation configuration, to set a custom attestation statement
   validity.
-  Defaults to 10 minutes (i.e. 600)
+  Defaults to 5 minutes (i.e. 300)
 - Fix verification time calculation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,149 +1,185 @@
 ## 0.1
+
 Initial Release
 
 ## 0.2
+
 Validation date can be specified
 
 ## 0.3
+
 Throw exception when attestation fails. This way, no logging framework is required to communicate the reason why
 attestation failed and the library works nicely with pure java
 
 ## 0.5
+
 - More idiomatic Kotlin
 - cleaner exception handling
 - download revocation list only once per chain
 
-## 0.6 
+## 0.6
+
 - maven publishing
 
 ## 0.7
+
 - produce jdk8 compatible build (using `jdk8` classifier)
 
 ### 0.7.2
+
 - Return ParsedAttestationRecord on Success
 
 ### 0.7.3
+
 - Include JavaDoc
 
 ### 0.7.4
+
 - More Java-friendly API
 - More detailed toplevel error messages on certificate verification fail
 - Kotlin 1.8.0
 
 ## 0.8
+
 - ability to ignore timely validity of leaf cert
 
 ### 0.8.2
+
 - more `@JvmOverloads`
 
 ### 0.8.3
+
 - MR Jar Release (Java 11 directly uses code from Google, Java 8 version uses adapted one for legacy support)
 - Drop `-jdk8` classifier for proper release to maven central
 
 ### 0.8.4
+
 - ability to configure custom trust anchors
 
 ### 0.8.5
+
 - updated upstream sources
 - cache revocation list
 
 ## 0.9.0
+
 - ability to add offset to time of verification (thanks @rolicz)
 - fix Java 8 builds (thanks @rolicz)
 
 ## 1.0.0
+
 - deprecate MR jar (= remove Java 8 support)
 - Build against JDK11
 - Kotlin 1.9.22
 - Update to latest `android-key-attestation` codebase from Google (2024-01-31)
 - Dependency updates:
-  - Bouncy Castle 1.77
-  - Ktor 2.3.7
-  - kotlinx.datetime 0.5.0
-  - Napier 2.7.1
-  - Guava 33.0.0-jre
-  - Error Prone 2.24.1
-  - (NEW) AutoValue 1.10.4
+    - Bouncy Castle 1.77
+    - Ktor 2.3.7
+    - kotlinx.datetime 0.5.0
+    - Napier 2.7.1
+    - Guava 33.0.0-jre
+    - Error Prone 2.24.1
+    - (NEW) AutoValue 1.10.4
+
 ### 0.9.2
+
 - drop broken java 8 target
 - update sources from upstream
 
 ### 0.9.3
+
 - add guava to API for java interop
 - kotlin-stdlib API dependency for java interop
-
 
 ## 1.0.0
 
 **This version introduces incompatible changes! Re-read the readme!**
 
-Most notably, it now supports configuring multiple applications, introduces optional software-only attestation and a new hybrid
+Most notably, it now supports configuring multiple applications, introduces optional software-only attestation and a new
+hybrid
 attestation checker, which caters towards legacy devices, which originally shipped with Android 7 (Nougat).
 Most of such devices support hardware attestation only for keys, but not for app/os-related information.
 <br>
 Moreover, a builder is now available for more Java-friendliness
 
-In addition, 1.0.0. introduces a new diagnostics tool (a runnable jar), which takes an attestation certificate and prints
+In addition, 1.0.0. introduces a new diagnostics tool (a runnable jar), which takes an attestation certificate and
+prints
 out the attestation record.
 
 ### 1.1.0
+
 - introduce builder for `AppData`
 
 ### 1.2.0
+
 - introduce well-defined error codes for every way an attestation can fail
 - refactor exception hierarchy as a consequence
 
 #### 1.2.1
+
 - make all config classes `data` classes
 
 ### 1.3.0
+
 - make configuration play nicely with file-based config loading (e.g. [HopLite](https://github.com/sksamuel/hoplite))
 
 ### 1.4.0
+
 - reorganized constructors for less confusing file-based config loading
 - update to latest conventions plugin
 - build against JDK11 as per gradle.properties
 
 ### 1.5.0
+
 - Kotlin 1.9.22
 - Update to latest `android-key-attestation` codebase from Google (2024-01-31)
 - Dependency updates:
-  - Bouncy Castle 1.77
-  - Ktor 2.3.7
-  - kotlinx.datetime 0.5.0
-  - Napier 2.7.1
-  - Guava 33.0.0-jre
-  - Error Prone 2.24.1
-  - (NEW) AutoValue 1.10.4
+    - Bouncy Castle 1.77
+    - Ktor 2.3.7
+    - kotlinx.datetime 0.5.0
+    - Napier 2.7.1
+    - Guava 33.0.0-jre
+    - Error Prone 2.24.1
+    - (NEW) AutoValue 1.10.4
 
 #### 1.5.1
+
 - dependency updated
 - correctly expose guava as api dependency
 
 #### 1.5.2
+
 - support HTTP proxy for fetching Android Revocation list
 - Dependency Updates:
-  -  Java 17
-  -  Kotlin 2.0.0
-  -  bouncycastle:  1.78.1!!
-  -  coroutines:    1.8.1
-  -  datetime:      0.6.0
-  -  kmmresult:     1.6.1
-  -  kotest:        5.9.1!!
-  -  kotlin:        2.0.0
-  -  ksp:           1.0.22
-  -  ktor:          2.3.11
-  -  napier:        2.7.1
-  -  nexus:         1.3.0
-  -  serialization: 1.7.1
+    - Java 17
+    - Kotlin 2.0.0
+    - bouncycastle:  1.78.1!!
+    - coroutines:    1.8.1
+    - datetime:      0.6.0
+    - kmmresult:     1.6.1
+    - kotest:        5.9.1!!
+    - kotlin:        2.0.0
+    - ksp:           1.0.22
+    - ktor:          2.3.11
+    - napier:        2.7.1
+    - nexus:         1.3.0
+    - serialization: 1.7.1
 
 ### 1.6.0
+
 - Rebrand to _WARDEN-roboto_
 - Update to latest upstream attestation code
-  - `rollbackResistant` -> `rollbackResistance`
-  - Dependency Updates
-    - Guava: 33.2.1-jre
-    - autovalue: 1.11.0
-    - protobuf-javalite: 4.27.0
+    - `rollbackResistant` -> `rollbackResistance`
+    - Dependency Updates
+        - Guava: 33.2.1-jre
+        - autovalue: 1.11.0
+        - protobuf-javalite: 4.27.0
 
-### 1.6.1-SNAPSHOT
+### 1.7.0 Breaking Changes Ahead!
+
+- Add `AttestationValueException.Reason.TIME` to indicate too far off or missing attestation statement creation
+  time inside the attestation statement (in contrast to Certificate validity issues)
+- Add `attestationStatementValiditySeconds` to Android attestation configuration, to set a custom attestation statement
+  validity.
+  Defaults to 10 minutes (i.e. 600)
+- Fix verification time calculation

--- a/README.md
+++ b/README.md
@@ -58,7 +58,10 @@ Three flavours of attestation are implemented:
 * Software attestation through [SoftwareAttestationChecker](https://github.com/a-sit-plus/warden-roboto/blob/main/warden-roboto/src/main/kotlin/SoftwareAttestationChecker.kt)
   (you typically don't want to use this)
 * Nougat hybrid attestation through [NougatHybridAttestationChecker](https://github.com/a-sit-plus/warden-roboto/blob/main/warden-roboto/src/main/kotlin/NougatHybridAttestationChecker.kt)
-  (you may require this to support legacy devices originally shipped with Android 7 (Nougat))
+  (you may require this to support legacy devices originally shipped with Android 7 (Nougat)). Does **NOT** support checking:
+    * Verified boot state and system image integrity
+    * Android version
+    * Attestation statement creation time
 
 All of these extend [AndroidAttestationChecker](https://github.com/a-sit-plus/warden-roboto/blob/main/warden-roboto/src/main/kotlin/AndroidAttestationChecker.kt)
 
@@ -100,6 +103,7 @@ AndroidAttestationConfiguration(
     hardwareAttestationTrustAnchors = linkedSetOf(*DEFAULT_HARDWARE_TRUST_ANCHORS), //OPTIONAL, defaults  shown here
     softwareAttestationTrustAnchors = linkedSetOf(*DEFAULT_SOFTWARE_TRUST_ANCHORS), //OPTIONAL, defaults  shown here
     verificationSecondsOffset = -300,       //OPTIONAL, defaults to 0
+    attestationStatementValiditySeconds = 0,//OPTIONAL, defaults to 300. Affects timestamp checks against the attestation statement creation, not the certificate.
     disableHardwareAttestation = false,     //OPTIONAL, defaults to false
     enableNougatAttestation = false,        //OPTIONAL, defaults to false
     enableSoftwareAttestation = false,      //OPTIONAL, defaults to false
@@ -107,7 +111,7 @@ AndroidAttestationConfiguration(
 )
 ```
 
-Additionally, a builder is available for smoohter java interoperability:
+Additionally, a builder is available for smoother java interoperability:
 
 ```java
 List<AndroidAttestationConfiguration.AppData> apps = new LinkedList<>();

--- a/warden-roboto/build.gradle.kts
+++ b/warden-roboto/build.gradle.kts
@@ -1,4 +1,5 @@
 import at.asitplus.gradle.bouncycastle
+import at.asitplus.gradle.datetime
 import at.asitplus.gradle.ktor
 import org.gradle.kotlin.dsl.support.listFilesOrdered
 import org.jetbrains.kotlin.gradle.targets.js.testing.karma.processKarmaStackTrace
@@ -59,6 +60,7 @@ dependencies {
     testImplementation("ch.qos.logback:logback-classic:1.2.3")
     testImplementation("ch.qos.logback:logback-access:1.2.3")
     testImplementation(ktor("client-mock"))
+    testImplementation(datetime())
 }
 
 

--- a/warden-roboto/src/main/kotlin/AndroidAttestationChecker.kt
+++ b/warden-roboto/src/main/kotlin/AndroidAttestationChecker.kt
@@ -287,7 +287,7 @@ abstract class AndroidAttestationChecker(
             "verification of attestation challenge failed",
             reason = AttestationValueException.Reason.CHALLENGE
         )
-        kotlin.runCatching {  parsedAttestationRecord.verifyAttestationTime(verificationDate)}.onFailure { it.printStackTrace(); throw it }
+        parsedAttestationRecord.verifyAttestationTime(verificationDate)
         parsedAttestationRecord.verifySecurityLevel()
         parsedAttestationRecord.verifyBootStateAndSystemImage()
         parsedAttestationRecord.verifyRollbackResistance()

--- a/warden-roboto/src/main/kotlin/AndroidAttestationConfiguration.kt
+++ b/warden-roboto/src/main/kotlin/AndroidAttestationConfiguration.kt
@@ -143,7 +143,7 @@ data class AndroidAttestationConfiguration @JvmOverloads constructor(
      * Validity of the attestation statement in seconds. This is not the certificate validity!
      * An attestation statement has a creation time. This value indicates how far in the past the creation time might be.
      */
-    val attestationStatementValiditySeconds: Int = 10 * 60,
+    val attestationStatementValiditySeconds: Int = 5 * 60,
 
     /**
      * Entirely disable creation of a [HardwareAttestationChecker]. Only change this flag, if you **really** know what

--- a/warden-roboto/src/main/kotlin/AndroidAttestationConfiguration.kt
+++ b/warden-roboto/src/main/kotlin/AndroidAttestationConfiguration.kt
@@ -140,6 +140,12 @@ data class AndroidAttestationConfiguration @JvmOverloads constructor(
     val verificationSecondsOffset: Int = 0,
 
     /**
+     * Validity of the attestation statement in seconds. This is not the certificate validity!
+     * An attestation statement has a creation time. This value indicates how far in the past the creation time might be.
+     */
+    val attestationStatementValiditySeconds: Int = 10 * 60,
+
+    /**
      * Entirely disable creation of a [HardwareAttestationChecker]. Only change this flag, if you **really** know what
      * you are doing!
      * @see enableSoftwareAttestation
@@ -234,6 +240,12 @@ data class AndroidAttestationConfiguration @JvmOverloads constructor(
         verificationSecondsOffset: Int = 0,
 
         /**
+         * Validity of the attestation statement in seconds. This is not the certificate validity!
+         * An attestation statement has a creation time. This value indicates how far in the past the creation time might be.
+         */
+        attestationStatementValiditySeconds: Int = 10 * 60,
+
+        /**
          * Entirely disable creation of a [HardwareAttestationChecker]. Only change this flag, if you **really** know what
          * you are doing!
          * @see enableSoftwareAttestation
@@ -271,6 +283,7 @@ data class AndroidAttestationConfiguration @JvmOverloads constructor(
         hardwareAttestationTrustAnchors = hardwareAttestationTrustAnchors,
         softwareAttestationTrustAnchors = softwareAttestationTrustAnchors,
         verificationSecondsOffset = verificationSecondsOffset,
+        attestationStatementValiditySeconds = attestationStatementValiditySeconds,
         disableHardwareAttestation = disableHardwareAttestation,
         enableNougatAttestation = enableNougatAttestation,
         enableSoftwareAttestation = enableSoftwareAttestation,
@@ -322,6 +335,12 @@ data class AndroidAttestationConfiguration @JvmOverloads constructor(
          *  Tolerance in seconds added to verification date
          */
         verificationSecondsOffset: Int = 0,
+
+        /**
+         * Validity of the attestation statement in seconds. This is not the certificate validity!
+         * An attestation statement has a creation time. This value indicates how far in the past the creation time might be.
+         */
+        attestationStatementValiditySeconds: Int = 10 * 60,
 
         /**
          * Entirely disable creation of a [HardwareAttestationChecker]. Only change this flag, if you **really** know what
@@ -386,6 +405,7 @@ data class AndroidAttestationConfiguration @JvmOverloads constructor(
         hardwareAttestationTrustAnchors = hardwareAttestationRootKeys.map { it.parsePublicKey() }.toSet(),
         softwareAttestationTrustAnchors = softwareAttestationRootKeys.map { it.parsePublicKey() }.toSet(),
         verificationSecondsOffset = verificationSecondsOffset,
+        attestationStatementValiditySeconds = attestationStatementValiditySeconds,
         disableHardwareAttestation = disableHardwareAttestation,
         enableNougatAttestation = enableNougatAttestation,
         enableSoftwareAttestation = enableSoftwareAttestation,
@@ -525,6 +545,8 @@ data class AndroidAttestationConfiguration @JvmOverloads constructor(
 
         private var verificationSecondsOffset = 0
 
+        private var attestationStatementValiditySeconds = 10 * 60
+
         private var disableHwAttestation: Boolean = false
         private var enableSwAttestation: Boolean = false
         private var enableNougatAttestation: Boolean = false
@@ -591,6 +613,12 @@ data class AndroidAttestationConfiguration @JvmOverloads constructor(
         fun verificationSecondsOffset(seconds: Int) = apply { verificationSecondsOffset = seconds }
 
         /**
+         * Validity of the attestation statement in seconds. This is not the certificate validity!
+         * An attestation statement has a creation time. This value indicates how far in the past the creation time might be.
+         */
+        fun attestationStatementValiditySeconds(seconds: Int) = apply { attestationStatementValiditySeconds = seconds }
+
+        /**
          * @see AndroidAttestationConfiguration.disableHardwareAttestation
          */
         fun disableHardwareAttestation() = apply { disableHwAttestation = true }
@@ -621,6 +649,7 @@ data class AndroidAttestationConfiguration @JvmOverloads constructor(
             hardwareAttestationTrustAnchors = hardwareAttestationTrustAnchors,
             softwareAttestationTrustAnchors = softwareAttestationTrustAnchors,
             verificationSecondsOffset = verificationSecondsOffset,
+            attestationStatementValiditySeconds = attestationStatementValiditySeconds,
             disableHardwareAttestation = disableHwAttestation,
             enableSoftwareAttestation = enableSwAttestation,
             enableNougatAttestation = enableNougatAttestation,

--- a/warden-roboto/src/main/kotlin/NougatHybridAttestationChecker.kt
+++ b/warden-roboto/src/main/kotlin/NougatHybridAttestationChecker.kt
@@ -11,6 +11,7 @@ import io.ktor.client.plugins.cache.*
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.request.*
 import io.ktor.serialization.kotlinx.json.*
+import java.time.Instant
 import java.util.*
 
 class NougatHybridAttestationChecker @JvmOverloads constructor(
@@ -58,7 +59,7 @@ class NougatHybridAttestationChecker @JvmOverloads constructor(
     @Throws(AttestationValueException::class)
     override fun ParsedAttestationRecord.verifyRollbackResistance() = teeEnforced().verifyRollbackResistance()
 
-    override fun ParsedAttestationRecord.verifyAttestationTime(verificationDate: Date) {
+    override fun ParsedAttestationRecord.verifyAttestationTime(verificationDate: Instant) {
         //impossible
     }
 }

--- a/warden-roboto/src/main/kotlin/NougatHybridAttestationChecker.kt
+++ b/warden-roboto/src/main/kotlin/NougatHybridAttestationChecker.kt
@@ -20,9 +20,9 @@ class NougatHybridAttestationChecker @JvmOverloads constructor(
 
     init {
         if (!attestationConfiguration.enableNougatAttestation) throw object :
-            AndroidAttestationException("Hardware attestation is disabled!", null) {}
+            AndroidAttestationException("Nougat attestation is disabled!", null) {}
         if (attestationConfiguration.hardwareAttestationTrustAnchors.isEmpty()) throw object :
-            AndroidAttestationException("No hardware attestation trust anchors configured", null) {}
+            AndroidAttestationException("No Nougat (Software) attestation trust anchors configured", null) {}
     }
 
     @Throws(AttestationValueException::class)
@@ -57,4 +57,8 @@ class NougatHybridAttestationChecker @JvmOverloads constructor(
 
     @Throws(AttestationValueException::class)
     override fun ParsedAttestationRecord.verifyRollbackResistance() = teeEnforced().verifyRollbackResistance()
+
+    override fun ParsedAttestationRecord.verifyAttestationTime(verificationDate: Date) {
+        //impossible
+    }
 }

--- a/warden-roboto/src/main/kotlin/exceptions/Throwables.kt
+++ b/warden-roboto/src/main/kotlin/exceptions/Throwables.kt
@@ -71,7 +71,13 @@ class AttestationValueException(message: String?, cause: Throwable? = null, val 
          * **Note** that this reason might be shadowed by a [CertificateInvalidException] with [CertificateInvalidException.Reason.TRUST]
          * since software and hardware attestation use different trust anchors
          */
-        SEC_LEVEL
+        SEC_LEVEL,
+
+
+        /**
+         * Indicates that the attestation statement creation time is too far off or missing
+         */
+        TIME
     }
 }
 

--- a/warden-roboto/src/test/kotlin/AttestationTests.kt
+++ b/warden-roboto/src/test/kotlin/AttestationTests.kt
@@ -76,7 +76,7 @@ class AttestationTests : FreeSpec() {
                     9mL1J1IXvmM=    
                     """
                 ),
-                isoDate = "2023-09-07T17:19:03.443Z",
+                isoDate = "2023-09-06T17:19:09Z",
                 pubKeyB64 = "MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAuOwpW9boeY2+tihDBAja17fOToCT2mdgUV9HC1xyN8y1" +
                         "pxUTEGGmWxaiVgy49ktl4QooMwOJd8rqcz/uyt4/okE6RvR4cpezPQ/h53eERDoasmxC6wERwg2MfA0Lqo7pY79gGmc2" +
                         "RXdMdFmMjSDJ0zQclhFJR5/zJhiqtN/RY2nIV9B/urBgRVxwcAMBsQ59zu4SM6O1aomBqxM9+IuC5ylcxwRgWkqLgjIj" +
@@ -310,7 +310,7 @@ class AttestationTests : FreeSpec() {
                         ex0SdDrx+tWUDqG8At2JHA==
                         """
                     ),
-                    isoDate = "2023-04-15T00:00:00Z",
+                    isoDate = "2023-04-14T13:12:42Z",
                     pubKeyB64 = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEL3PdP8200NNz3h4p0bcwrPikiD5+s/qPXN/eHikTd8RnQiutcz4tqAq4NXgcmjLiEcNIOtkPTKi45ETDEoqPpA=="
                 ),
                 AttestationData(
@@ -384,7 +384,7 @@ class AttestationTests : FreeSpec() {
                         ex0SdDrx+tWUDqG8At2JHA==
                         """
                     ),
-                    isoDate = "2023-04-15T00:00:00Z",
+                    isoDate = "2023-04-14T14:31:42Z",
                     pubKeyB64 = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEqs5NcBOKN40tu/5+NLFvGRMRcYF6KRksYoUmiwlKhhzbGaALzE2PerEM5wzNKeC6ESruZJRoBPuHn5D+HfoMkA=="
                 ),
 

--- a/warden-roboto/src/test/kotlin/AttestationTests.kt
+++ b/warden-roboto/src/test/kotlin/AttestationTests.kt
@@ -14,7 +14,8 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 import io.ktor.util.*
 import org.bouncycastle.util.encoders.Base64
 import java.sql.Date
-import java.time.Duration
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
 
 
 @OptIn(ExperimentalStdlibApi::class)
@@ -515,7 +516,7 @@ class AttestationTests : FreeSpec() {
                                         recordedAttestation.attestationCertChain,
                                         Date.from(
                                             recordedAttestation.verificationDate.toInstant()
-                                                .minus(Duration.ofDays(30000))
+                                                .minus(java.time.Duration.ofDays(30000))
                                         ),
                                         recordedAttestation.challenge
                                     )
@@ -528,7 +529,7 @@ class AttestationTests : FreeSpec() {
                                         recordedAttestation.attestationCertChain,
                                         Date.from(
                                             recordedAttestation.verificationDate.toInstant()
-                                                .plus(Duration.ofDays(30000))
+                                                .plus(java.time.Duration.ofDays(30000))
                                         ),
                                         recordedAttestation.challenge
                                     )
@@ -632,7 +633,8 @@ fun attestationService(
     androidPatchLevel: PatchLevel? = PatchLevel(2021, 8),
     requireStrongBox: Boolean = false,
     unlockedBootloaderAllowed: Boolean = false,
-    requireRollbackResistance: Boolean = false
+    requireRollbackResistance: Boolean = false,
+    attestationStatementValiditiy: Duration = 5.minutes
 ) = HardwareAttestationChecker(
     AndroidAttestationConfiguration(
         listOf(
@@ -646,7 +648,9 @@ fun attestationService(
         patchLevel = androidPatchLevel,
         requireStrongBox = requireStrongBox,
         allowBootloaderUnlock = unlockedBootloaderAllowed,
-        requireRollbackResistance = requireRollbackResistance
+        requireRollbackResistance = requireRollbackResistance,
+        attestationStatementValiditySeconds = attestationStatementValiditiy.inWholeSeconds.toInt()
+
     )
 )
 

--- a/warden-roboto/src/test/kotlin/TemporalOffsetTest.kt
+++ b/warden-roboto/src/test/kotlin/TemporalOffsetTest.kt
@@ -1,0 +1,131 @@
+package at.asitplus.attestation.android
+
+import at.asitplus.attestation.android.exceptions.AndroidAttestationException
+import at.asitplus.attestation.android.exceptions.AttestationValueException
+import at.asitplus.attestation.data.AttestationData
+import at.asitplus.attestation.data.attestationCertChain
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.datatest.withData
+import io.kotest.matchers.string.shouldContain
+import kotlinx.datetime.toJavaInstant
+import kotlinx.datetime.toKotlinInstant
+import java.util.*
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+class TemporalOffsetTest : FreeSpec() {
+
+    private val exactStartOfValidity: Map<String, AttestationData> = mapOf(
+        "KeyMint 200" to AttestationData(
+            "Pixel 6",
+            challengeB64 = "9w11c/H1kgfx+2Lqrqscug==",
+            attestationProofB64 = listOf(
+                """
+                        MIICpzCCAk6gAwIBAgIBATAKBggqhkjOPQQDAjA5MQwwCgYDVQQKEwNURUUxKTAnBgNVBAMTIGQ3MWRmYjM1NjNlNWQ5Y2I0NmRkMTJjMWJhMjI2YzM5MB4XDTIzMDQxNDE0MzAyMVoXDTQ4M
+                        DEwMTAwMDAwMFowJTEjMCEGA1UEAxMaaHR0cDovLzE5Mi4xNjguMTc4LjMzOjgwODAwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASqzk1wE4o3jS27/n40sW8ZExFxgXopGSxihSaLCUqGHN
+                        sZoAvMTY96sQznDM0p4LoRKu5klGgE+4efkP4d+gyQo4IBWTCCAVUwDgYDVR0PAQH/BAQDAgeAMIIBQQYKKwYBBAHWeQIBEQSCATEwggEtAgIAyAoBAQICAMgKAQEEEPcNdXPx9ZIH8fti6q6
+                        rHLoEADBfv4U9CAIGAYeALKLxv4VFTwRNMEsxJTAjBB5hdC5hc2l0cGx1cy5hdHRlc3RhdGlvbl9jbGllbnQCAQExIgQgNLl2LE1skNSEMZQMV73nMUJYsmQg7+Fqx/cnTw0zCtUwgaehCDEG
+                        AgECAgEDogMCAQOjBAICAQClCDEGAgECAgEEqgMCAQG/g3cCBQC/hT4DAgEAv4VATDBKBCAPbnXIAYO13sB0sAVNQnHpk4nr5LE2sIGd4fFQug/51wEB/woBAAQgNidLYFH3o3y3ufJGD1UzB
+                        8M0ZzGpxDl7RrvUI0SJSwi/hUEFAgMB+9C/hUIFAgMDFj+/hU4GAgQBNLChv4VPBgIEATSwoTAKBggqhkjOPQQDAgNHADBEAiAYJTfwNDCSiw/fob8VIBSNnXfaQaoyLxVmbaP/U5e2AgIgAl
+                        ngbOcR1syv1RP369hnI8cMh4xe1AFnB+H3Y9OVirQ=
+                        """,
+                """
+                        MIIBwzCCAWqgAwIBAgIRANcd+zVj5dnLRt0SwboibDkwCgYIKoZIzj0EAwIwKTETMBEGA1UEChMKR29vZ2xlIExMQzESMBAGA1UEAxMJRHJvaWQgQ0EzMB4XDTIzMDMyNjExNDk0OVoXDTIzM
+                        DUwMTExNDk0OVowOTEMMAoGA1UEChMDVEVFMSkwJwYDVQQDEyBkNzFkZmIzNTYzZTVkOWNiNDZkZDEyYzFiYTIyNmMzOTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABJS3ylJ9AibrkDPP/W
+                        4PBHmHU/e+yRiSTr4nLkojZzkBDWayhRI6PhrsN8Cetsp2EG2r2dQ60VnPvtvw9ElYYlGjYzBhMB0GA1UdDgQWBBQRvZZGVqzjrxcT1lU/u8OGt6xJSjAfBgNVHSMEGDAWgBTEfQBQs7lkcRy
+                        V+Ok7Vmuti/ra9zAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwICBDAKBggqhkjOPQQDAgNHADBEAiAjV7E60YcWRMdplr3lyh/M6nSHuADoGWdO10hP2h/81gIgTRHSnjjwPA3FGlyY
+                        g8DGschrg3a7j8lEzLg2kRmzg9c=
+                        """,
+                """
+                        MIIB1jCCAVygAwIBAgITKqOs6sgL8zCfdZ1InqRvUR51szAKBggqhkjOPQQDAzApMRMwEQYDVQQKEwpHb29nbGUgTExDMRIwEAYDVQQDEwlEcm9pZCBDQTIwHhcNMjMwMzI3MjMxMzUyWhcNM
+                        jMwNTAxMjMxMzUxWjApMRMwEQYDVQQKEwpHb29nbGUgTExDMRIwEAYDVQQDEwlEcm9pZCBDQTMwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQGyo5Rgphmke9X1N+/0OBQzlUIsfWudjeXWa
+                        FQOUl8VKN9y00pYQlyICzNAC4A9/f92tNhF3RkCn//Xfae9zcDo2MwYTAOBgNVHQ8BAf8EBAMCAgQwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQUxH0AULO5ZHEclfjpO1ZrrYv62vcwHwY
+                        DVR0jBBgwFoAUu/g2rYmubOLlnpTw1bLX0nrkfEEwCgYIKoZIzj0EAwMDaAAwZQIwffCbRJ9FCtNJopq2R2L0cpeoLKZTmu3SD2tcnU1CxBbEnhBA8Jl1giOBPsdB+VrPAjEA74XTlWF8C2Um
+                        zwiCRxemo+tlw9EJ752ljAIwlUOWErA40tIGRe18736YdxM/zC8X
+                        """,
+                """
+                        MIIDgDCCAWigAwIBAgIKA4gmZ2BliZaGDTANBgkqhkiG9w0BAQsFADAbMRkwFwYDVQQFExBmOTIwMDllODUzYjZiMDQ1MB4XDTIyMDEyNjIyNDc1MloXDTM3MDEyMjIyNDc1MlowKTETMBEGA
+                        1UEChMKR29vZ2xlIExMQzESMBAGA1UEAxMJRHJvaWQgQ0EyMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEuppxbZvJgwNXXe6qQKidXqUt1ooT8M6Q+ysWIwpduM2EalST8v/Cy2JN10aqTfUSTh
+                        Jha/oCtG+F9TUUviOch6RahrpjVyBdhopM9MFDlCfkiCkPCPGu2ODMj7O/bKnko2YwZDAdBgNVHQ4EFgQUu/g2rYmubOLlnpTw1bLX0nrkfEEwHwYDVR0jBBgwFoAUNmHhAHyIBQlRi0RsR/8
+                        aTMnqTxIwEgYDVR0TAQH/BAgwBgEB/wIBAjAOBgNVHQ8BAf8EBAMCAQYwDQYJKoZIhvcNAQELBQADggIBAIFxUiFHYfObqrJM0eeXI+kZFT57wBplhq+TEjd+78nIWbKvKGUFlvt7IuXHzZ7Y
+                        JdtSDs7lFtCsxXdrWEmLckxRDCRcth3Eb1leFespS35NAOd0Hekg8vy2G31OWAe567l6NdLjqytukcF4KAzHIRxoFivN+tlkEJmg7EQw9D2wPq4KpBtug4oJE53R9bLCT5wSVj63hlzEY3hC0
+                        NoSAtp0kdthow86UFVzLqxEjR2B1MPCMlyIfoGyBgkyAWhd2gWN6pVeQ8RZoO5gfPmQuCsn8m9kv/dclFMWLaOawgS4kyAn9iRi2yYjEAI0VVi7u3XDgBVnowtYAn4gma5q4BdXgbWbUTaMVV
+                        VZsepXKUpDpKzEfss6Iw0zx2Gql75zRDsgyuDyNUDzutvDMw8mgJmFkWjlkqkVM2diDZydzmgi8br2sJTLdG4lUwvedIaLgjnIDEG1J8/5xcPVQJFgRf3m5XEZB4hjG3We/49p+JRVQSpE1+Q
+                        zG0raYpdNsxBUO+41diQo7qC7S8w2J+TMeGdpKGjCIzKjUDAy2+gOmZdZacanFN/03SydbKVHV0b/NYRWMa4VaZbomKON38IH2ep8pdj++nmSIXeWpQE8LnMEdnUFjvDzp0f0ELSXVW2+5xbl
+                        +fcqWgmOupmU4+bxNJLtknLo49Bg5w9jNn7T7rkF
+                        """,
+                """
+                        MIIFHDCCAwSgAwIBAgIJANUP8luj8tazMA0GCSqGSIb3DQEBCwUAMBsxGTAXBgNVBAUTEGY5MjAwOWU4NTNiNmIwNDUwHhcNMTkxMTIyMjAzNzU4WhcNMzQxMTE4MjAzNzU4WjAbMRkwFwYDV
+                        QQFExBmOTIwMDllODUzYjZiMDQ1MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAr7bHgiuxpwHsK7Qui8xUFmOr75gvMsd/dTEDDJdSSxtf6An7xyqpRR90PL2abxM1dEqlXnf2tq
+                        w1Ne4Xwl5jlRfdnJLmN0pTy/4lj4/7tv0Sk3iiKkypnEUtR6WfMgH0QZfKHM1+di+y9TFRtv6y//0rb+T+W8a9nsNL/ggjnar86461qO0rOs2cXjp3kOG1FEJ5MVmFmBGtnrKpa73XpXyTqRx
+                        B/M0n1n/W9nGqC4FSYa04T6N5RIZGBN2z2MT5IKGbFlbC8UrW0DxW7AYImQQcHtGl/m00QLVWutHQoVJYnFPlXTcHYvASLu+RhhsbDmxMgJJ0mcDpvsC4PjvB+TxywElgS70vE0XmLD+OJtvs
+                        BslHZvPBKCOdT0MS+tgSOIfga+z1Z1g7+DVagf7quvmag8jfPioyKvxnK/EgsTUVi2ghzq8wm27ud/mIM7AY2qEORR8Go3TVB4HzWQgpZrt3i5MIlCaY504LzSRiigHCzAPlHws+W0rB5N+er
+                        5/2pJKnfBSDiCiFAVtCLOZ7gLiMm0jhO2B6tUXHI/+MRPjy02i59lINMRRev56GKtcd9qO/0kUJWdZTdA2XoS82ixPvZtXQpUpuL12ab+9EaDK8Z4RHJYYfCT3Q5vNAXaiWQ+8PTWm2QgBR/b
+                        kwSWc+NpUFgNPN9PvQi8WEg5UmAGMCAwEAAaNjMGEwHQYDVR0OBBYEFDZh4QB8iAUJUYtEbEf/GkzJ6k8SMB8GA1UdIwQYMBaAFDZh4QB8iAUJUYtEbEf/GkzJ6k8SMA8GA1UdEwEB/wQFMAM
+                        BAf8wDgYDVR0PAQH/BAQDAgIEMA0GCSqGSIb3DQEBCwUAA4ICAQBOMaBc8oumXb2voc7XCWnuXKhBBK3e2KMGz39t7lA3XXRe2ZLLAkLM5y3J7tURkf5a1SutfdOyXAmeE6SRo83Uh6Wszodm
+                        MkxK5GM4JGrnt4pBisu5igXEydaW7qq2CdC6DOGjG+mEkN8/TA6p3cnoL/sPyz6evdjLlSeJ8rFBH6xWyIZCbrcpYEJzXaUOEaxxXxgYz5/cTiVKN2M1G2okQBUIYSY6bjEL4aUN5cfo7ogP3
+                        UvliEo3Eo0YgwuzR2v0KR6C1cZqZJSTnghIC/vAD32KdNQ+c3N+vl2OTsUVMC1GiWkngNx1OO1+kXW+YTnnTUOtOIswUP/Vqd5SYgAImMAfY8U9/iIgkQj6T2W6FsScy94IN9fFhE1UtzmLoB
+                        IuUFsVXJMTz+Jucth+IqoWFua9v1R93/k98p41pjtFX+H8DslVgfP097vju4KDlqN64xV1grw3ZLl4CiOe/A91oeLm2UHOq6wn3esB4r2EIQKb6jTVGu5sYCcdWpXr0AUVqcABPdgL+H7qJgu
+                        Bw09ojm6xNIrw2OocrDKsudk/okr/AwqEyPKw9WnMlQgLIKw1rODG2NvU9oR3GVGdMkUBZutL8VuFkERQGt6vQ2OCw0sV47VMkuYbacK/xyZFiRcrPJPb41zgbQj9XAEyLKCHex0SdDrx+tWU
+                        DqG8At2JHA==
+                        """
+            ),
+            isoDate = "2023-04-14T14:30:22Z", //need to round up millis
+            pubKeyB64 = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEqs5NcBOKN40tu/5+NLFvGRMRcYF6KRksYoUmiwlKhhzbGaALzE2PerEM5wzNKeC6ESruZJRoBPuHn5D+HfoMkA=="
+        )
+    )
+
+    init {
+        "Exact Time of Validity" - {
+            withData(exactStartOfValidity) {
+                attestationService().verifyAttestation(
+                    it.attestationCertChain,
+                    it.verificationDate,
+                    it.challenge
+                )
+            }
+        }
+
+        "Exact Time of Validity + 1D" - {
+            withData(exactStartOfValidity) {
+                attestationService(
+                    attestationStatementValiditiy = 1.days + 1.seconds
+                ).verifyAttestation(
+                    it.attestationCertChain,
+                    Date.from((it.verificationDate.toInstant().toKotlinInstant() + 1.days).toJavaInstant()),
+                    it.challenge,
+                )
+            }
+        }
+
+        "Exact Time of Validity - 1D" - {
+            withData(exactStartOfValidity) {
+                withData(exactStartOfValidity) {
+                    shouldThrow<AttestationValueException> {
+                        attestationService().verifyAttestation(
+                            it.attestationCertChain,
+                            Date.from((it.verificationDate.toInstant().toKotlinInstant() - 1.seconds).toJavaInstant()),
+                            it.challenge,
+                        )
+                    }.message!!.shouldContain("too far in the future")
+                }
+
+
+                withData(exactStartOfValidity) {
+                    shouldThrow<AttestationValueException> {
+                        attestationService().verifyAttestation(
+                            it.attestationCertChain,
+                            Date.from((it.verificationDate.toInstant().toKotlinInstant() + 10.minutes).toJavaInstant()),
+                            it.challenge,
+                        )
+                    }.message!!.shouldContain("too far in the past")
+                }
+
+            }
+
+        }
+    }
+}
+


### PR DESCRIPTION
- Add `AttestationValueException.Reason.TIME` to indicate too far off or missing attestation statement creation
  time inside the attestation statement (in contrast to Certificate validity issues)
- Add `attestationStatementValiditySeconds` to Android attestation configuration, to set a custom attestation statement
  validity.
  Defaults to 5 minutes (i.e. 300)
- Fix verification time calculation