### PR TITLE
Feature/per app trust anchors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## NEXT
 * Integrate Google's new PKI cert path validator
     * This provides an additional safety net against cert path manipulation
+* Per-App trust anchor overrides
+* BEHAVIOURAL CHANGE:
+  * Per-App trust anchor overrides changes the order of checks on Android:
+    * App-metadata checks are now performed first
+    * Consequence: package, signature, … mismatches are reported even before certificate chain validation errors
 * More insightful error messages on attestation failure
 * Kotlin 2.1.21
 * Bouncy Castle 1.81

--- a/README.md
+++ b/README.md
@@ -91,7 +91,10 @@ AndroidAttestationConfiguration(
             signatureDigests = listOf("NLl2LE1skNSEMZQMV73nMUJYsmQg7=".encodeToByteArray()),
             appVersion = 2, //with a different versioning scheme
             androidVersionOverride = 130000, //so we need to override this
-            patchLevelOverride = PatchLevel(2023, 6) //also override patch level
+            patchLevelOverride = PatchLevel(2023, 6), //also override patch level
+            trustAnchorOverrides = setOf(extraTrustedRootPubKey) // set this app to require
+                                                                 // a custom root for trust for the
+                                                                 // attestation certificate chain
         )
     ),
     androidVersion = 110000,                //OPTIONAL, null by default

--- a/warden-roboto/src/main/kotlin/AndroidAttestationChecker.kt
+++ b/warden-roboto/src/main/kotlin/AndroidAttestationChecker.kt
@@ -54,9 +54,9 @@ abstract class AndroidAttestationChecker(
     private val revocationListClient = HttpClient(CIO) { setup(attestationConfiguration.httpProxy) }
 
     @Throws(CertificateInvalidException::class, RevocationException::class)
-    private fun List<X509Certificate>.verifyCertificateChain(verificationDate: Date) {
+    private fun List<X509Certificate>.verifyCertificateChain(verificationDate: Date, actualTrustAnchors: Collection<PublicKey>) {
 
-        runCatching { verifyRootCertificate(verificationDate) }
+        runCatching { verifyRootCertificate(verificationDate, actualTrustAnchors) }
             .onFailure {
                 throw if (it is CertificateInvalidException) it else CertificateInvalidException(
                     "could not verify root certificate (valid from: ${last().notBefore} to ${last().notAfter}), verification date: $verificationDate",
@@ -138,10 +138,10 @@ abstract class AndroidAttestationChecker(
         }
     }
 
-    private fun List<X509Certificate>.verifyRootCertificate(verificationDate: Date) {
+    private fun List<X509Certificate>.verifyRootCertificate(verificationDate: Date, actualTrustAnchors: Collection<PublicKey>) {
         val root = last()
         root.checkValidity(verificationDate)
-        val matchingTrustAnchor = trustAnchors
+        val matchingTrustAnchor = actualTrustAnchors
             .firstOrNull { root.publicKey.encoded.contentEquals(it.encoded) }
             ?: run {
                 val additionalInfo =
@@ -344,9 +344,20 @@ abstract class AndroidAttestationChecker(
     ): ParsedAttestationRecord {
         val actualVerificationDate =
             Date.from(verificationDate.toInstant().plusSeconds(attestationConfiguration.verificationSecondsOffset))
-        certificates.verifyCertificateChain(actualVerificationDate)
 
+
+        //do this before we check everything else to actually identify the app we're having here
         val parsedAttestationRecord = ParsedAttestationRecord.createParsedAttestationRecord(certificates)
+        val attestedApp = attestationConfiguration.applications.associateWith { app ->
+            runCatching { parsedAttestationRecord.verifyApplication(app) }
+        }.let {
+            it.entries.firstOrNull { (_, result) -> result.isSuccess } ?: it.values.first().exceptionOrNull()!!
+                .let { throw it }
+        }.key
+
+        val thisAppsTrustAnchors = attestedApp.trustAnchorOverrides?:trustAnchors
+        certificates.verifyCertificateChain(actualVerificationDate, thisAppsTrustAnchors)
+
         if (!verifyChallenge(
                 expectedChallenge,
                 parsedAttestationRecord.attestationChallenge().toByteArray()
@@ -360,12 +371,7 @@ abstract class AndroidAttestationChecker(
         parsedAttestationRecord.verifyBootStateAndSystemImage()
         parsedAttestationRecord.verifyRollbackResistance()
 
-        val attestedApp = attestationConfiguration.applications.associateWith { app ->
-            runCatching { parsedAttestationRecord.verifyApplication(app) }
-        }.let {
-            it.entries.firstOrNull { (_, result) -> result.isSuccess } ?: it.values.first().exceptionOrNull()!!
-                .let { throw it }
-        }.key
+
         parsedAttestationRecord.verifyAndroidVersion(attestedApp.androidVersionOverride, attestedApp.patchLevelOverride)
         return parsedAttestationRecord
     }

--- a/warden-roboto/src/main/kotlin/AndroidAttestationConfiguration.kt
+++ b/warden-roboto/src/main/kotlin/AndroidAttestationConfiguration.kt
@@ -467,6 +467,11 @@ data class AndroidAttestationConfiguration @JvmOverloads constructor(
          */
         internal val patchLevelOverride: PatchLevel? = null,
 
+        /**
+         * optional parameter. If set, all globally configured trust anchors are discarded and only the trust anchors specified here are used to attest this app.
+         */
+        val trustAnchorOverrides: Set<@Serializable(with = PubKeyBasePemSerializer::class) PublicKey>? = null,
+
         ) {
         init {
             if (signatureDigests.isEmpty()) throw object :
@@ -503,6 +508,8 @@ data class AndroidAttestationConfiguration @JvmOverloads constructor(
             private var androidVersionOverride: Int? = null
             private var patchLevelOverride: PatchLevel? = null
 
+            private var trustAnchorOverrides: Set<PublicKey>? = null
+
             /**
              * @see AppData.appVersion
              */
@@ -518,8 +525,20 @@ data class AndroidAttestationConfiguration @JvmOverloads constructor(
              */
             fun overridePatchLevel(level: PatchLevel) = apply { patchLevelOverride = level }
 
+            /**
+             * optional parameter. If set, all globally configured trust anchors are discarded and only the trust anchors specified here are used to attest this app.
+             */
+            fun overrideTrustAnchors(trustAnchors: Set<PublicKey>) = apply { trustAnchorOverrides = trustAnchors }
+
             fun build() =
-                AppData(packageName, signatureDigests, appVersion, androidVersionOverride, patchLevelOverride)
+                AppData(
+                    packageName,
+                    signatureDigests,
+                    appVersion,
+                    androidVersionOverride,
+                    patchLevelOverride,
+                    trustAnchorOverrides
+                )
         }
 
         override fun toString(): String {
@@ -670,7 +689,8 @@ data class AndroidAttestationConfiguration @JvmOverloads constructor(
          *
          * **Can be set to `null` to ignore attestation statement validity checking.** In this case, even a faulty attestation statement lacking a creation time will verify.
          */
-        fun attestationStatementValiditySeconds(seconds: Long?) = apply { attestationStatementValiditySeconds = seconds }
+        fun attestationStatementValiditySeconds(seconds: Long?) =
+            apply { attestationStatementValiditySeconds = seconds }
 
         /**
          * @see AndroidAttestationConfiguration.disableHardwareAttestation

--- a/warden-roboto/src/test/kotlin/FakeAttestationTests.kt
+++ b/warden-roboto/src/test/kotlin/FakeAttestationTests.kt
@@ -3,7 +3,6 @@ package at.asitplus.attestation.android
 import at.asitplus.attestation.android.exceptions.CertificateInvalidException
 import at.asitplus.attestation.data.AttestationCreator
 import at.asitplus.attestation.data.AttestationData
-import at.asitplus.attestation.data.attestationCertChain
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
@@ -33,7 +32,8 @@ class FakeAttestationTests : FreeSpec({
                 AndroidAttestationConfiguration.AppData(
                     packageName = packageName,
                     signatureDigests = listOf(signatureDigest),
-                    appVersion = appVersion),
+                    appVersion = appVersion
+                ),
                 androidVersion = androidVersion,
                 patchLevel = patchLevel,
                 requireStrongBox = false,
@@ -58,14 +58,16 @@ class FakeAttestationTests : FreeSpec({
                     AndroidAttestationConfiguration.AppData(
                         packageName = packageName,
                         signatureDigests = listOf(signatureDigest),
-                        appVersion = appVersion),
+                        appVersion = appVersion
+                    ),
                     androidVersion = androidVersion,
                     patchLevel = patchLevel,
                     requireStrongBox = false,
                     allowBootloaderUnlock = false,
                     ignoreLeafValidity = false,
                     hardwareAttestationTrustAnchors = setOf(borkedAttestation.last().publicKey)
-                )).verifyAttestation(
+                )
+            ).verifyAttestation(
                 certificates = borkedAttestation,
                 expectedChallenge = challenge
             )
@@ -141,14 +143,15 @@ class FakeAttestationTests : FreeSpec({
 
         }
 
-        "but not with a real cert from a real device" {
+        "but not with a real cert from a real device" - {
 
             val checker = HardwareAttestationChecker(
                 AndroidAttestationConfiguration(
                     AndroidAttestationConfiguration.AppData(
                         packageName = packageName,
                         signatureDigests = listOf(signatureDigest),
-                        appVersion = appVersion),
+                        appVersion = appVersion
+                    ),
                     androidVersion = androidVersion,
                     patchLevel = patchLevel,
                     requireStrongBox = false,
@@ -160,6 +163,54 @@ class FakeAttestationTests : FreeSpec({
             shouldThrow<CertificateInvalidException> {
                 checker.verifyAttestation(attestationProof, expectedChallenge = challenge)
             }.reason shouldBe CertificateInvalidException.Reason.TRUST
+
+            "unless overridden" {
+                val checker = HardwareAttestationChecker(
+                    AndroidAttestationConfiguration(
+                        AndroidAttestationConfiguration.AppData(
+                            packageName = packageName,
+                            signatureDigests = listOf(signatureDigest),
+                            appVersion = appVersion,
+                            trustAnchorOverrides = setOf(attestationProof.last().publicKey)
+                        ),
+                        androidVersion = androidVersion,
+                        patchLevel = patchLevel,
+                        requireStrongBox = false,
+                        allowBootloaderUnlock = false,
+                        ignoreLeafValidity = false,
+                    )
+                )
+                checker.verifyAttestation(
+                    certificates = attestationProof,
+                    expectedChallenge = challenge
+                )
+            }
+
+            shouldThrow<CertificateInvalidException> {
+                checker.verifyAttestation(attestationProof, expectedChallenge = challenge)
+            }.reason shouldBe CertificateInvalidException.Reason.TRUST
+
+            "but never without trust anchors" {
+                val checker = HardwareAttestationChecker(
+                    AndroidAttestationConfiguration(
+                        AndroidAttestationConfiguration.AppData(
+                            packageName = packageName,
+                            signatureDigests = listOf(signatureDigest),
+                            appVersion = appVersion,
+                            trustAnchorOverrides = setOf()
+                        ),
+                        androidVersion = androidVersion,
+                        patchLevel = patchLevel,
+                        requireStrongBox = false,
+                        allowBootloaderUnlock = false,
+                        ignoreLeafValidity = false,
+                    )
+                )
+                shouldThrow<CertificateInvalidException> {
+                    checker.verifyAttestation(attestationProof, expectedChallenge = challenge)
+                }.reason shouldBe CertificateInvalidException.Reason.TRUST
+            }
+
         }
 
         "and the fake attestation must not verify against the google root key" {

--- a/warden-roboto/src/test/kotlin/FakeAttestationTests.kt
+++ b/warden-roboto/src/test/kotlin/FakeAttestationTests.kt
@@ -143,8 +143,22 @@ class FakeAttestationTests : FreeSpec({
 
         "but not with a real cert from a real device" {
 
+            val checker = HardwareAttestationChecker(
+                AndroidAttestationConfiguration(
+                    AndroidAttestationConfiguration.AppData(
+                        packageName = packageName,
+                        signatureDigests = listOf(signatureDigest),
+                        appVersion = appVersion),
+                    androidVersion = androidVersion,
+                    patchLevel = patchLevel,
+                    requireStrongBox = false,
+                    allowBootloaderUnlock = false,
+                    ignoreLeafValidity = false,
+                )
+            )
+
             shouldThrow<CertificateInvalidException> {
-                checker.verifyAttestation(nokia.attestationCertChain, expectedChallenge = nokia.challenge)
+                checker.verifyAttestation(attestationProof, expectedChallenge = challenge)
             }.reason shouldBe CertificateInvalidException.Reason.TRUST
         }
 


### PR DESCRIPTION
Per-App trust anchor overrides changes the order of checks on Android:
    * App-metadata checks are now performed first
    * Consequence: package, signature, … mismatches are reported even before certificate chain validation errors